### PR TITLE
Title Bar Height - shrink for use with erskyTX w/ status bar

### DIFF
--- a/edgeTx/SCRIPTS/TOOLS/UNI-Activate_v2.lua
+++ b/edgeTx/SCRIPTS/TOOLS/UNI-Activate_v2.lua
@@ -336,14 +336,15 @@ local function run(event)
       lcd.setColor(TEXT_INVERTED_BGCOLOR, ThmTexInvBgCol)
     else
       lcd.setColor(CUSTOM_COLOR, GRAY1)
-      lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, CUSTOM_COLOR)     --Backround Area
+      lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, CUSTOM_COLOR)     --Background Area
       if ValidRead == 1 and ValidValue ==0 then
         lcd.setColor(CUSTOM_COLOR, RED)                             --Title Bar for LOCKED
       else
         lcd.setColor(CUSTOM_COLOR, GREEN1)
       end
-        lcd.drawFilledRectangle(0, 0, LCD_W, 28, CUSTOM_COLOR)      --Title Bar
-        lcd.drawRectangle(0, 26, LCD_W, 2, BLACK, 2)                --Separator Line
+      lcd.drawFilledRectangle(0, 0, LCD_W, 25, CUSTOM_COLOR)        --Title Bar
+      lcd.setColor(CUSTOM_COLOR, BLACK)
+      lcd.drawRectangle(0, 25, LCD_W, 2, CUSTOM_COLOR, 2)           --Separator Line
     end
   end
 

--- a/edgeTx/SCRIPTS/TOOLS/UNI-Setup_v4.lua
+++ b/edgeTx/SCRIPTS/TOOLS/UNI-Setup_v4.lua
@@ -885,14 +885,15 @@ local function run(event)
       lcd.setColor(TEXT_INVERTED_BGCOLOR, ThmTexInvBgCol)
     else
       lcd.setColor(CUSTOM_COLOR, GRAY1)
-      lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, CUSTOM_COLOR)     --Backround Area
+      lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, CUSTOM_COLOR)     --Background Area
       if Resetting > 0 then
         lcd.setColor(CUSTOM_COLOR, RED)                             --Title Bar for Reset
       else
         lcd.setColor(CUSTOM_COLOR, GOLD1)
       end
-        lcd.drawFilledRectangle(0, 0, LCD_W, 28, CUSTOM_COLOR)      --Title Bar
-        lcd.drawRectangle(0, 26, LCD_W, 2, BLACK, 2)                --Separator Line
+      lcd.drawFilledRectangle(0, 0, LCD_W, 25, CUSTOM_COLOR)        --Title Bar
+      lcd.setColor(CUSTOM_COLOR, BLACK)
+      lcd.drawRectangle(0, 25, LCD_W, 2, CUSTOM_COLOR, 2)           --Separator Line
     end
   end
 

--- a/edgeTx/SCRIPTS/TOOLS/UNI-Statistics_v6.lua
+++ b/edgeTx/SCRIPTS/TOOLS/UNI-Statistics_v6.lua
@@ -349,10 +349,11 @@ local function run(event)
       lcd.setColor(TEXT_INVERTED_BGCOLOR, ThmTexInvBgCol)
     else
       lcd.setColor(CUSTOM_COLOR, GRAY1)
-      lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, CUSTOM_COLOR)     --Backround Area
+      lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, CUSTOM_COLOR)     --Background Area
       lcd.setColor(CUSTOM_COLOR, BLUE1)
-      lcd.drawFilledRectangle(0, 0, LCD_W, 28, CUSTOM_COLOR)        --Title Bar
-      lcd.drawRectangle(0, 26, LCD_W, 2, BLACK, 2)                  --Separator Line
+      lcd.drawFilledRectangle(0, 0, LCD_W, 25, CUSTOM_COLOR)        --Title Bar
+      lcd.setColor(CUSTOM_COLOR, BLACK)
+      lcd.drawRectangle(0, 25, LCD_W, 2, CUSTOM_COLOR, 2)           --Separator Line
     end
   end
 


### PR DESCRIPTION
Shorten Title bar height for use with erskyTX that is also using a bottom status bar.
Because of the status bar it only has 240 pixel screen height available for lua use. 
Also tested on OTX and ETX 272 height screens without any visual problems.

Rich