### PR TITLE
Make result global to not offset refresh function retransmission timing

### DIFF
--- a/edgeTx/SCRIPTS/TOOLS/UNI-Activate.lua
+++ b/edgeTx/SCRIPTS/TOOLS/UNI-Activate.lua
@@ -37,6 +37,7 @@ local ValidValue = 0
 local ValidRead = 0
 local SendingCode = 0
 local UpdateValue = 0
+local result = 0 -- needed global to not affect timing of refreshSetup
 
 -- Computed depending on screen size at initialization
 local wfpx, hfpx, hfpxLast, posrep, xpos_L, xpos_R, smSiz, bigSiz
@@ -106,7 +107,6 @@ local function sendRead(value)
 end
 
 local function refreshSetup()
-  local result = 0
   --local i = 0 -- is i used??
 
   if getTime() - now > 60 then

--- a/edgeTx/SCRIPTS/TOOLS/UNI-Setup.lua
+++ b/edgeTx/SCRIPTS/TOOLS/UNI-Setup.lua
@@ -52,6 +52,7 @@ local Crates = -1
 local FbusOK = 0
 
 local limit = 0
+local result = 0   -- make result global to not offset refreshServo timing
 
 -- Computed based on screen size at initialization
 local  wfpx, hfpx, hfpxLast, posrep, smSiz, bigSiz, xpos_L, xpos_R, txtSiz_R
@@ -451,7 +452,6 @@ local function refreshServoRates()
   if getTime() - now > 60 then
     now = now + 60
     keepAlive = 0
-    local result
     if Rate == -1 then
       result = sendRead(0xE6)
     elseif Crates == -1 then


### PR DESCRIPTION
Based on feedback from Mike, changing this to global to make the re-transmission timing work properly